### PR TITLE
Added upload size limit

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,8 @@ class User < ActiveRecord::Base
 
   has_attached_file :image, styles: { medium: "300x300>", thumb: "100x100#" }, default_url: "/images/:style/missing.png"
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\z/
+  validates_attachment_size :image, :less_than => 5.megabytes
+
 
   @@roster_file_name = "EAB_roster.xml"
   @@roster_file_directory = Rails.root.to_s


### PR DESCRIPTION
Small change. Set a size limit cap to uploaded photos. Paperclip will automatically notify user through UI. 