### PR TITLE
Hide fb linked in

### DIFF
--- a/app/views/users/_display_users.html.haml
+++ b/app/views/users/_display_users.html.haml
@@ -36,14 +36,14 @@
                 %p.user-about.skillset= "Skills: #{user.skillset}"
 
             %div.user-contact
-              - if user.facebook
+              - if user.facebook && !user.facebook.empty?
                 %a.contact.fb{:target => "_blank", :href => "https://www.#{user.facebook}"}
                   %i.fab.fa-lg.fa-facebook-square
               - else
                 %a.contact.fb.inactive
                   %i.fab.fa-lg.fa-facebook-square
 
-              - if user.linkedinLstring
+              - if user.linkedinLstring && !user.linkedinLstring.empty?
                 %a.contact.linkedin{:target => "_blank", :href => "https://www.#{user.linkedinLstring}"}
                   %i.fab.fa-lg.fa-linkedin
               - else

--- a/app/views/users/registrations/edit.html.haml
+++ b/app/views/users/registrations/edit.html.haml
@@ -68,11 +68,11 @@
 
           .row
             .field.col-md-6
-              = f.label "Full LinkedIn URL"
+              = f.label "LinkedIn URL \(no https or www\)"
               %br/
               = f.text_field :linkedinLstring, autofocus: true, class: %w[input form-control]
             .field.col-md-6
-              = f.label "Full Facebook URL"
+              = f.label "Facebook URL \(no https or www\)"
               %br/
               = f.text_field :facebook, autofocus: true, class: %w[input form-control]
 
@@ -88,15 +88,6 @@
             %div
               Currently waiting confirmation for: #{resource.unconfirmed_email}
 
-          .row
-            .field.col-md-6
-              = f.label "Full LinkedIn URL"
-              %br/
-              = f.text_field :linkedinLstring, autofocus: true, class: %w[input form-control]
-            .field.col-md-6
-              = f.label "Full Facebook URL"
-              %br/
-              = f.text_field :facebook, autofocus: true, class: %w[input form-control]
           .field
             = f.label :password
             %i (leave blank if you don't want to change it)

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -29,11 +29,19 @@
               = @emailDomain
         %tr
           %td.socialMedia{ style: 'font-size: 2.6rem; text-align: center;' }
-            %a{:href => "https://www.#{@user.facebook}"}
-              %i.fab.fa-facebook-square
+            - if @user.facebook && !@user.facebook.empty?
+              %a.contact.fb{:target => "_blank", :href => "https://www.#{@user.facebook}"}
+                %i.fab.fa-lg.fa-facebook-square
+            - else
+              %a.contact.fb.inactive
+                %i.fab.fa-lg.fa-facebook-square
 
-            %a{:href => "https://www.#{@user.linkedinLstring}"}
-              %i.fab.fa-linkedin
+            - if @user.linkedinLstring && !@user.linkedinLstring.empty?
+              %a.contact.linkedin{:target => "_blank", :href => "https://www.#{@user.linkedinLstring}"}
+                %i.fab.fa-lg.fa-linkedin
+            - else
+              %a.contact.linkedin.inactive
+                %i.fab.fa-lg.fa-linkedin
 
     %div.profile-filler-wrapper.col-1
     %div.profile-main-wrapper.col-9

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,6 +20,13 @@ ActiveRecord::Schema.define(version: 20190427213816) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "posts", force: :cascade do |t|
+    t.string   "title"
+    t.string   "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "teams", force: :cascade do |t|
     t.string   "name"
     t.string   "description"


### PR DESCRIPTION
LinkedIn and Facebook links are properly unclickable when user has no link there. Also the duplicate fields for editting the links have been removed. This fix does not prevent invalid links or links that are not from facebook/linkedIn. 

**Note: our site may be vulnerable to CSRF or phishing (due to the fact that anybody can place whatever link they want under their fb/linkedIn icons). Shouldn't be much of an issue as ideally this site is an internal tool. 