### PR TITLE
Password confirmation optional

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:first, :last, :sid, :code])
-    devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:first, :last, :email, :password, :current_password, :team, :year, :major, :skillset, :sid, :linkedinLstring, :facebook, :image) }
+    devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:first, :last, :email, :password, :current_password, :password_confirmation, :team, :year, :major, :skillset, :sid, :linkedinLstring, :facebook, :image) }
   end
 
   def after_sign_in_path_for(resource)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -61,7 +61,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def update_resource(resource, params)
-    if params[:password].blank? && params[:password_confirmation].blank? && params[:email].blank?
+    if params[:password].blank? && params[:password_confirmation].blank? && params[:email].eql?(@user.email)
+      params.delete(:current_password)
       resource.update_without_password(params)
     else
       super

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -60,13 +60,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
     redirect_to users_path, flash: {notice: "User was successfully deleted"}
   end
 
-  # def update_resource(resource, params)
-  #   if params[:password].blank? && params[:password_confirmation].blank? && params[:email].blank?
-  #     resource.update_without_password(params)
-  #   else
-  #     super
-  #   end
-  # end
+  def update_resource(resource, params)
+    if params[:password].blank? && params[:password_confirmation].blank? && params[:email].blank?
+      resource.update_without_password(params)
+    else
+      super
+    end
+  end
   
   # def update_resource(resource, params)
   #   resource.update_without_password(params)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -25,6 +25,33 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
+  # def update
+  #   self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
+
+
+  #   # custom logic
+  #   if params[:current_password].blank?
+  #     resource.update_without_password(params)
+  #   else
+  #     resource.update_with_password(params)
+  #   end
+
+  #   # standart devise behaviour
+  #   if result
+  #     if is_navigational_format?
+  #       if resource.respond_to?(:pending_reconfirmation?) && resource.pending_reconfirmation?
+  #         flash_key = :update_needs_confirmation
+  #       end
+  #       set_flash_message :notice, flash_key || :updated
+  #     end
+  #     sign_in resource_name, resource, :bypass => true
+  #     respond_with resource, :location => after_update_path_for(resource)
+  #   else
+  #     clean_up_passwords resource
+  #     respond_with resource
+  #   end
+  # end
+
   # DELETE /resource
   def destroy
     @user = User.find(params[:toDelete])
@@ -33,10 +60,17 @@ class Users::RegistrationsController < Devise::RegistrationsController
     redirect_to users_path, flash: {notice: "User was successfully deleted"}
   end
 
+  # def update_resource(resource, params)
+  #   if params[:password].blank? && params[:password_confirmation].blank? && params[:email].blank?
+  #     resource.update_without_password(params)
+  #   else
+  #     super
+  #   end
+  # end
   
-  def update_resource(resource, params)
-    resource.update_without_password(params)
-  end
+  # def update_resource(resource, params)
+  #   resource.update_without_password(params)
+  # end
 
   # GET /resource/cancel
   # Forces the session data which is usually expired after sign

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -33,6 +33,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
     redirect_to users_path, flash: {notice: "User was successfully deleted"}
   end
 
+  
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
+
   # GET /resource/cancel
   # Forces the session data which is usually expired after sign
   # in to be expired now. This is useful if the user wants to

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ActiveRecord::Base
 	validates :first, :last, :email, :sid, presence: true
   validate :correct_access_code
 
+
   has_attached_file :image, styles: { medium: "300x300>", thumb: "100x100#" }, default_url: "/images/:style/missing.png"
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\z/
     validates_attachment_size :image, :less_than => 5.megabytes
@@ -18,8 +19,6 @@ class User < ActiveRecord::Base
   scope :search_team_name, lambda { |search|
     joins(:team).where("lower(name) LIKE lower(?)", "%#{search}%").order(:first)}
 
-  attr_accessor :current_password
-  validates_confirmation_of :password_confirmation
 
 
   ##Custom Validation methods

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 	validates :sid, uniqueness: true
@@ -15,6 +17,10 @@ class User < ActiveRecord::Base
 
   scope :search_team_name, lambda { |search|
     joins(:team).where("lower(name) LIKE lower(?)", "%#{search}%").order(:first)}
+
+  attr_accessor :current_password
+  validates_confirmation_of :password_confirmation
+
 
   ##Custom Validation methods
   def correct_access_code

--- a/app/views/users/registrations/edit.html.haml
+++ b/app/views/users/registrations/edit.html.haml
@@ -89,13 +89,12 @@
               Currently waiting confirmation for: #{resource.unconfirmed_email}
 
           .field
-            = f.label :password
-            %i (leave blank if you don't want to change it)
+            = f.label "New Password"
             %br/
             = f.password_field :password, autocomplete: "new-password", class: %w[input form-control]
 
           .field
-            = f.label :password_confirmation
+            = f.label "Confirm new password"
             %br/
             = f.password_field :password_confirmation, autocomplete: "new-password", class: %w[input form-control]
 
@@ -107,7 +106,7 @@
 
           .field
             = f.label :current_password
-            %i (we need your current password to confirm your changes)
+            %i (needed to make changes to email or password)
             %br/
             = f.password_field :current_password, autocomplete: "current-password", class: %w[input form-control]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
   patch 'teams/update/:id', to: 'teams#update', as: 'update_team'
 
   delete 'teams/delete/:id', to: 'teams#delete', as: 'delete_team'
+  
 
   # get 'users/:id/edit', to: 'users#edit', as: 'edit_page'
 

--- a/features/edit_account.feature
+++ b/features/edit_account.feature
@@ -12,5 +12,5 @@ Scenario: User can edit their profile info
     And I follow "View Profile"
     Then I should see the link "Edit Account"
     When I follow "Edit Account"
-    Then I should see "leave blank if you don't want to change it"
-    And I should see "we need your current password to confirm your changes"
+    Then I should see "New password"
+    And I should see "needed to make changes to email or password"

--- a/features/edit_account.feature
+++ b/features/edit_account.feature
@@ -14,3 +14,38 @@ Scenario: User can edit their profile info
     When I follow "Edit Account"
     Then I should see "New password"
     And I should see "needed to make changes to email or password"
+    When I fill in "user_linkedinLstring" with "reddit.com"
+    And I press "Update"
+    Then I should see "Your account has been updated successfully."
+
+
+Scenario: User cannot edit their password without current password
+    Given I exist as a user
+    And I sign in with valid credentials
+    And I follow "More"
+    And I follow "View Profile"
+    Then I should see the link "Edit Account"
+    When I follow "Edit Account"
+    Then I should see "New password"
+    And I should see "needed to make changes to email or password"
+    When I fill in "user_password" with "123456"
+    And I fill in "user_password_confirmation" with "123456"
+    And I press "Update"
+    Then I should see "Current password can't be blank"
+
+
+Scenario: User can edit their password with current password
+    Given I exist as a user
+    And I sign in with valid credentials
+    And I follow "More"
+    And I follow "View Profile"
+    Then I should see the link "Edit Account"
+    When I follow "Edit Account"
+    Then I should see "New password"
+    And I should see "needed to make changes to email or password"
+    When I fill in "user_password" with "123456"
+    And I fill in "user_password_confirmation" with "123456"
+    And I fill in "user_current_password" with my password
+    And I press "Update"
+    Then I should see "Your account has been updated successfully."
+

--- a/features/step_definitions/users_steps.rb
+++ b/features/step_definitions/users_steps.rb
@@ -352,6 +352,9 @@ When /^I change the "(.*)" to "(.*)"$/ do |code_type, code|
   step %{I press "Change #{code_type}"}
 end
 
+When /^(?:|I )fill in "([^"]*)" with my password$/ do |field|
+  fill_in(field, :with => @visitor[:password])
+end
 
 ### THEN ###
 Then /^I should be an admin$/ do
@@ -474,3 +477,5 @@ Then /^my team's "(.*)" should be "(.*)"/ do |column, value|
   update_user_variable
   expect(@user.team.send(column.to_sym)).to eq(value)
 end
+
+


### PR DESCRIPTION
Entering "Current password' is optional outside of changing user email/password. 

--Additional fix in this pull request: password confirmation(the field wouldn't matter before) for editting is properly working. 